### PR TITLE
Fix the prom version and update command line params

### DIFF
--- a/prometheus-deployment.yaml
+++ b/prometheus-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: prometheus-deployment
+  namespace: monitoring
 spec:
   replicas: 1
   template:
@@ -11,10 +12,10 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: prom/prometheus:latest
+          image: prom/prometheus:v2.1.0
           args:
-            - "-config.file=/etc/prometheus/prometheus.yml"
-            - "-storage.local.path=/prometheus/"
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus/"
           ports:
             - containerPort: 9090
           volumeMounts:
@@ -29,4 +30,4 @@ spec:
             name: prometheus-server-conf
   
         - name: prometheus-storage-volume
-          emptyDir: {} 
+          emptyDir: {}


### PR DESCRIPTION
Enforced the prometheus version to latest (at time of writing) which should keep the tutorial working consistently.

As part of the change also updated the command line params.