### PR TITLE
'v1beta1' deprecated => changed to 'v1'

### DIFF
--- a/clusterRole.yaml
+++ b/clusterRole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -19,7 +19,7 @@ rules:
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus


### PR DESCRIPTION
The previous clusterRole.yaml would result in a warning from kubectl
that the version 'v1beta1' is deprecated.

Changing this to 'apiVersion: v1' instead.